### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-deploy-docker-image.yml
+++ b/.github/workflows/build-deploy-docker-image.yml
@@ -33,7 +33,7 @@ jobs:
         draft: false
         prerelease: false
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: tannedruse101/customer_complaint_analyzer # CHANGE THIS to your DockerHub username and repository!
         username: ${{ secrets.DOCKER_USERNAME }} # you need to add your Docker username to this GitHub repo as a secret


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore